### PR TITLE
navigation and destroy

### DIFF
--- a/AvaloniaApp.Tests/TestHelper/FakeViewModel2.cs
+++ b/AvaloniaApp.Tests/TestHelper/FakeViewModel2.cs
@@ -15,5 +15,10 @@ namespace AvaloniaApp.Tests.TestHelper
         {
             animal = GetAs<Animal>(@params);
         }
+
+        public override void RefreshPage()
+        {
+            animal.Breed = "тест";
+        }
     }
 }

--- a/AvaloniaLearning/NavService/INavigationService.cs
+++ b/AvaloniaLearning/NavService/INavigationService.cs
@@ -10,6 +10,12 @@ namespace AvaloniaApp.NavService
         void Navigate<TViewModel, TParams>(TParams @params)
             where TViewModel : ViewModelBase;
 
+        public void DestroyAndNavigate<TViewModel>()
+            where TViewModel : ViewModelBase;
+
+        public void DestroyAndNavigate<TViewModel, TParams>(TParams @params)
+            where TViewModel : ViewModelBase;
+
         void NavigateBack();
     }
 }

--- a/AvaloniaLearning/NavService/NavigationService.cs
+++ b/AvaloniaLearning/NavService/NavigationService.cs
@@ -70,7 +70,7 @@ namespace AvaloniaApp.NavService
         public void Navigate<TViewModel>()
             where TViewModel : ViewModelBase
         {
-            ViewModelBase? viewModel = _serviceProvider.GetRequiredService<TViewModel>();
+            ViewModelBase viewModel = _serviceProvider.GetRequiredService<TViewModel>();
             PushToHistoryAndSetViewModel(viewModel);
         }
 
@@ -89,7 +89,7 @@ namespace AvaloniaApp.NavService
         public void Navigate<TViewModel, TParams>(TParams @params)
             where TViewModel : ViewModelBase
         {
-            ViewModelBase? viewModel = _serviceProvider.GetRequiredService<TViewModel>();
+            ViewModelBase viewModel = _serviceProvider.GetRequiredService<TViewModel>();
             viewModel.Initialize(@params);
             PushToHistoryAndSetViewModel(viewModel);
         }
@@ -119,10 +119,16 @@ namespace AvaloniaApp.NavService
             {
                 return;
             }
-
+            _navStore.CurrentViewModel?.Dispose();
             ViewModelBase viewModel = _historyNavigation.Pop();
             viewModel.RefreshPage();
             _navStore.CurrentViewModel = viewModel;
+        }
+
+        public void DestroyAndNavigate<TViewModel>() where TViewModel : ViewModelBase
+        {
+            ViewModelBase viewModel = _serviceProvider.GetRequiredService<TViewModel>();
+            DisposeAndSetViewModel(viewModel);
         }
 
         /// <summary>
@@ -151,13 +157,23 @@ namespace AvaloniaApp.NavService
             _navStore.CurrentViewModel = viewModel;
         }
 
+        private void DisposeAndSetViewModel(ViewModelBase viewModel)
+        {
+            if (_navStore.CurrentViewModel != null)
+            {
+                _navStore.CurrentViewModel.Dispose();
+            }
+            _navStore.CurrentViewModel = viewModel;
+        }
+
         /// <summary>
         /// Функция для удаления первой записи истории
         /// </summary>
         private void RemoveLastVM()
         {
             _historyNavigation = new Stack<ViewModelBase>(_historyNavigation);
-            _historyNavigation.Pop();
+            ViewModelBase vm = _historyNavigation.Pop();
+            vm.Dispose();
             _historyNavigation = new Stack<ViewModelBase>(_historyNavigation);
         }
     }

--- a/AvaloniaLearning/ViewModel/MainPageViewModel.cs
+++ b/AvaloniaLearning/ViewModel/MainPageViewModel.cs
@@ -47,7 +47,7 @@ namespace AvaloniaApp.ViewModel
         }
 
         [RelayCommand]
-        private void NavToBack() => _navService.NavigateBack();
+        private void NavToBack() => _navService.DestroyAndNavigate<StartPageViewModel>();
 
         [RelayCommand]
         private void NavToEditUser(int id)

--- a/AvaloniaLearning/ViewModel/StartPageViewModel.cs
+++ b/AvaloniaLearning/ViewModel/StartPageViewModel.cs
@@ -11,6 +11,6 @@ namespace AvaloniaApp.ViewModel
             _navService = navService;
         }
 
-        public void NavToMain() => _navService.Navigate<MainPageViewModel>();
+        public void NavToMain() => _navService.DestroyAndNavigate<MainPageViewModel>();
     }
 }

--- a/AvaloniaLearning/ViewModel/ViewModelBase/ViewModelBase.cs
+++ b/AvaloniaLearning/ViewModel/ViewModelBase/ViewModelBase.cs
@@ -77,6 +77,12 @@ namespace AvaloniaApp.ViewModel
             );
         }
 
+        /// <summary>
+        /// Переопределяемый метод для освобождения ресурсов
+        /// </summary>
+        /// <remarks>
+        /// Базовая реализация отменяет финализацию
+        /// </remarks>
         public virtual void Dispose()
         {
             GC.SuppressFinalize(this);

--- a/AvaloniaLearning/ViewModel/ViewModelBase/ViewModelBase.cs
+++ b/AvaloniaLearning/ViewModel/ViewModelBase/ViewModelBase.cs
@@ -12,7 +12,7 @@ namespace AvaloniaApp.ViewModel
     /// - Инициализации ViewModel с параметрами
     /// - Безопасного приведения типов параметров
     /// </remarks>
-    public class ViewModelBase : ObservableObject
+    public class ViewModelBase : ObservableObject, IDisposable
     {
         /// <summary>
         /// Инициализирует ViewModel с указанными параметрами.
@@ -75,6 +75,11 @@ namespace AvaloniaApp.ViewModel
             throw new ArgumentException(
                 $"Expected type {typeof(T).Name}, but got {@params?.GetType().Name ?? "null"}"
             );
+        }
+
+        public virtual void Dispose()
+        {
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
Добавление навигации с очисткой старой ViewModel и без ее сохранения в историю. А также добавление реализации базового Dispose для ViewModelBase, чтобы все наследники могли переопределить его поведение. Вызывается при NavigateBack и DestroyAndNavigate.

Покрытие функционала unit тестами 